### PR TITLE
Fixed deprecated yield_fixture to "fixture"

### DIFF
--- a/examples/headless/test_demo.py
+++ b/examples/headless/test_demo.py
@@ -44,7 +44,7 @@ def _generate_param_ids(name, values):
     return [("<%s:%s>" % (name, value)).replace('.', '_') for value in values]
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def driver(request, browser_config):
     desired_caps = dict()
     desired_caps.update(browser_config)
@@ -60,7 +60,7 @@ def driver(request, browser_config):
     desired_caps['username'] = username
     desired_caps['accessKey'] = access_key
 
-    executor = RemoteConnection(selenium_endpoint, resolve_ip=False)
+    executor = RemoteConnection(selenium_endpoint)
     browser = webdriver.Remote(executor, desired_capabilities=desired_caps)
 
     yield browser
@@ -70,14 +70,14 @@ def driver(request, browser_config):
     browser.quit()
 
 @pytest.mark.usefixtures("driver")
-def test_valid_crentials_login(driver):
+def test_valid_credentials_login(driver):
     driver.get('http://www.saucedemo.com')
 
     driver.find_element(By.ID, 'user-name').send_keys('locked_out_user')
     driver.find_element(By.ID, 'password').send_keys('secret_sauce')
     driver.find_element(By.ID, '.btn_action').click()
 
-    assert driver.find_element(By.CSS_SELECTOR'.error-button').is_displayed()
+    assert driver.find_element(By.CSS_SELECTOR, '.error-button').is_displayed()
 
 
 @pytest.mark.usefixtures("driver")


### PR DESCRIPTION
Fixed deprecate "yield_fixtue" -> "fixture"
Fixed RemoteConnection call. (resolve_ip is not a parameter in __init__) 
Fixed syntax error - comma missing after By.CSS_SELECTOR
Fixed suspicious name "crentials" -> "credentials"

**NOTICE**: Testing these changes requires an enterprise account. Since I don't have an enterprise account, there was NO DEVELOPER TESTING. Apologies. I don't usually submit changes to github untested, but this is an extenuating circumstance. Testing before merging this commit is advised.