### PR TITLE
Add caps to desktop_web_driver setup

### DIFF
--- a/best_practice/conftest.py
+++ b/best_practice/conftest.py
@@ -138,6 +138,7 @@ def desktop_web_driver(request, data_center):
 
     browser = webdriver.Remote(
         command_executor=selenium_endpoint,
+        desired_capabilities=caps,
         options=webdriver.ChromeOptions(),
         keep_alive=True
     )


### PR DESCRIPTION
`caps` was being configured but not passed to the webdriver for desktop tests.